### PR TITLE
BUGFIX: allow for multiple --include arguments

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -65,8 +65,10 @@ for file_item in compilation_database:
     if source_exist_at(file_path) and not file_path in source_list:
         source_list.append(file_path)
 if args.includes:
+    matched_list = []
     for inclusion_filter in args.includes:
-        source_list = source_list_inclusion_filter(source_list, inclusion_filter)
+        matched_list.extend( source_list_inclusion_filter(source_list, inclusion_filter) )
+    source_list = matched_list
 if args.excludes:
     for exclusion_filter in args.excludes:
         source_list = source_list_exclusion_filter(source_list, exclusion_filter)


### PR DESCRIPTION
When multiple --include arguments are given, the list of source files is matched againts all of them in an **and** fashion, which means that usually an empty list is returned. This changeset processes multiple includes as **or** operation, so that if a file matches any of the patterns it will be included.