### PR TITLE
Make print for for python2 and python3

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -49,11 +49,11 @@ def source_list_exclusion_filter(source_list, exclusion_filter):
     return filtered_list
 
 if not source_exist_at(OCLINT_BIN):
-    print "Error: OCLint executable file not found."
+    print("Error: OCLint executable file not found.")
     sys.exit(99)
 
 if not source_exist_at(JSON_COMPILATION_DATABASE):
-    print "Error: compile_commands.json not found at current location."
+    print("Error: compile_commands.json not found at current location.")
     sys.exit(98)
 
 compilation_database = json.load(open(JSON_COMPILATION_DATABASE))
@@ -81,8 +81,8 @@ if args.debug:
     debug_argument = ' -debug'
 oclint_invocation = OCLINT_BIN + debug_argument + oclint_arguments + ' ' + source_paths
 if args.invocation:
-    print '------------------------------ OCLint ------------------------------'
-    print oclint_invocation
-    print '--------------------------------------------------------------------'
+    print('------------------------------ OCLint ------------------------------')
+    print(oclint_invocation)
+    print('--------------------------------------------------------------------')
 exit_code = subprocess.call(oclint_invocation, shell=True)
 sys.exit(exit_code)


### PR DESCRIPTION
As far as I can see, the only thing in the script that does not work in python3 are the print statements. If we enclose all the strings in parenthesis, they will be treated as a function call in python3 and will work just fine in python2 because they are treated as an expression. Tested with 2.7.9 and 3.3.5. This would make the scipt usable in systems that only have python3. This is an alternative to #5