### PR TITLE
Add travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+
+install:
+  - touch oclint
+  - chmod +x oclint
+  - echo "{}" > compile_commands.json
+
+script:
+  ./oclint-json-compilation-database -v


### PR DESCRIPTION
While the current version of the script works with both python2 and
python3, we should ensure that future changes do not break for either
python2 or python3.

The test only calls oclint-json-compilation-database -v for now. In the
future we might want to test against the actual oclint binary using real
compilation database files.