### PR TITLE
Fix error when the path to binary contains spaces

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -79,7 +79,7 @@ if args.oclint_args:
 debug_argument = ''
 if args.debug:
     debug_argument = ' -debug'
-oclint_invocation = OCLINT_BIN + debug_argument + oclint_arguments + ' ' + source_paths
+oclint_invocation = '"' + OCLINT_BIN + '"' + debug_argument + oclint_arguments + ' ' + source_paths
 if args.invocation:
     print('------------------------------ OCLint ------------------------------')
     print(oclint_invocation)


### PR DESCRIPTION
If the path to `oclint-json-compilation-database` file contains spaces (e.g. /Users/test/path to/oclint/oclint-json-compilation-database) it fails to run raising an error message.  
This patch fixes the issue.