### PR TITLE
adds -c command to specify compile_commands.json file

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -16,6 +16,7 @@ CURRENT_WORKING_DIRECTORY = os.getcwd()
 JSON_COMPILATION_DATABASE = CURRENT_WORKING_DIRECTORY + os.sep + "compile_commands.json"
 
 arg_parser = argparse.ArgumentParser(description='OCLint for JSON Compilation Database (compile_commands.json)')
+arg_parser.add_argument("-c", action="store", dest="command", help="specifies the json-compilation-database file")
 arg_parser.add_argument("-v", action="store_true", dest="invocation", help="show invocation command with arguments")
 arg_parser.add_argument('-debug', '--debug', action="store_true", dest="debug", help="invoke OCLint in debug mode")
 arg_parser.add_argument('-i', '-include', '--include', action='append', dest='includes', help="extract files matching pattern")
@@ -51,6 +52,9 @@ def source_list_exclusion_filter(source_list, exclusion_filter):
 if not source_exist_at(OCLINT_BIN):
     print("Error: OCLint executable file not found.")
     sys.exit(99)
+
+if args.command:
+    JSON_COMPILATION_DATABASE = args.command
 
 if not source_exist_at(JSON_COMPILATION_DATABASE):
     print("Error: compile_commands.json not found at current location.")


### PR DESCRIPTION
This change adds a `-c COMMAND`option to define an external compile_commands.json file.

I'm currently having a problem that's related to oclint, when the `json-compile-database` is defined outside, I'm receiving some times the following error:

`Could not auto-detect compilation database for file` for a file that works if the `json-compile-database` file is defined as `compile_commands.json` in the parent directory of the project
