### PR TITLE
Fixed a bug that does not work properly if the project path contains …

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -32,6 +32,7 @@ def get_source_path(file_attr, dir_attr):
         return dir_attr + os.sep + file_attr
 
 def source_exist_at(path):
+    decodedPath = path.replace("\\ ", " ");
     return os.path.isfile(path)
 
 def source_list_inclusion_filter(source_list, inclusion_filter):


### PR DESCRIPTION
…spaces.

If the path of the project to be analyzed by OCLint includes spaces as shown in the following example, an error occurs in the existence confirmation of the target path and it is not processed normally.

Project path like:
/Users/me/My Project/MyApp/Someware

For example, in compile_commands.json created with the option -r json-compilation-database in the xcpretty command, the space contained in the path is escaped with a backslash like this, but oclint-json-compilation-database do not care about this.

JSON contained like this:
“/Users/me/My\ /Users/me/My”

Likewise, in the path of the compile command returned by clang::tooling::CompileCommand in oclint-driver/lib/Driver.cpp, escape with backslash well if the path contains spaces. It also needed a fix.